### PR TITLE
Easier Compliation on GNU/Linux

### DIFF
--- a/EndianStuff.h
+++ b/EndianStuff.h
@@ -9,7 +9,9 @@
 
 #pragma once
 
+#if MAC_CODE
 #include <Carbon/Carbon.h>	// For Endian.h
+#endif
 #include <stdint.h>
 
 #if TARGET_RT_BIG_ENDIAN

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ functionality, you'll also have to write code to replace the Mac-specific code (
 resource fork of the stack and converts 'snd ' resources to AIFF -- the resource-fork-reading code in
 https://github.com/uliwitness/reclassicfication may be a good starting point).
 
+For example, using g++:
+`g++ woba.cpp picture.cpp main.cpp CWAVEFile.cpp CStackFile.cpp CSndResource.cpp CResourceFile.cpp CBuf.cpp byteutils.cpp -std=gnu++11`
+
 
 How to use this
 ---------------

--- a/main.cpp
+++ b/main.cpp
@@ -1,5 +1,8 @@
 #include <iostream>
 #include <unistd.h>
+#if !MAC_CODE
+#include <linux/limits.h>
+#endif
 #include "CStackFile.h"
 
 


### PR DESCRIPTION
Two changes that allow for immediate compilation on recent versions of GNU/Linux:
1. Removed dependancy on the Mac-specific <Carbon/Carbon.h> libraries to allow for compilation on non-Mac systems.
2. Incuded <linux/limits.h> as a new dependency so that PATH_MAX can be used on Linux systems.

The result of this PR is that compilation on recent versions of GNU/Linux can be archived simply be cloning the repository and running gcc.
A note detailing an example gcc command that compiles a working binary has been added to the README.
